### PR TITLE
Fix: Support emojis

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,14 +63,8 @@ class Typewriter {
         const segments =
             typeof Intl != 'undefined' && Intl.Segmenter
                 ? [...new Intl.Segmenter().segment(value)]
-                : value.split('').map((segment, index) => ({ segment, index }));
-        const values = [''];
-        let current = '';
-        segments.forEach(({ segment }) => {
-            current += segment;
-            values.push(current);
-        });
-        return values;
+                : value.split('').map((segment) => ({ segment }));
+        return segments.reduce((acc, { segment }, index) => [...acc, acc[index] + segment], ['']);
     }
 
     backspace() {

--- a/src/index.js
+++ b/src/index.js
@@ -120,27 +120,27 @@ export default function (Alpine) {
     Alpine.directive(
         'typewriter',
         (el, { expression, modifiers }, { evaluate }) => {
-        const texts = evaluate(expression);
+            const texts = evaluate(expression);
 
             const timeModifiers = modifiers.filter((modifier) =>
                 modifier.match(/^\d+m?s$/),
             );
-        const latestTimeModifier = timeModifiers.pop();
-        let milliseconds = null;
-        if (latestTimeModifier) {
+            const latestTimeModifier = timeModifiers.pop();
+            let milliseconds = null;
+            if (latestTimeModifier) {
                 if (latestTimeModifier.endsWith('ms')) {
                     milliseconds = parseInt(
                         latestTimeModifier.match(/^(\d+)/)[1],
                     );
-            } else {
+                } else {
                     milliseconds =
                         parseInt(latestTimeModifier.match(/^(\d+)s/)[1]) * 1000;
+                }
             }
-        }
 
             const showCursor = modifiers.includes('cursor');
 
-        new Typewriter(el, texts, milliseconds, showCursor).start().then();
+            new Typewriter(el, texts, milliseconds, showCursor).start().then();
         },
     );
 }


### PR DESCRIPTION
## Before

![Screenshot 2024-11-29 at 23 24 19](https://github.com/user-attachments/assets/8536ca8f-56ff-4ed7-992f-c7a5ab29976f)

## After

![Screenshot 2024-11-29 at 23 25 29](https://github.com/user-attachments/assets/f0efca20-1171-4d4d-8459-fea35418b3dd)

Before a string with `Hello 🙋‍♀️` would have been split in following parts:

```
[ 'H', 'e', 'l', 'l', 'o', ' ', '�', '�', '‍', '♀', '️' ]
```

but with the help of `Intl.Segmenter` (with the default `split` call as fallback) it now split the string correctly:

```
[ 'H', 'e', 'l', 'l', 'o', ' ', '🙋‍♀️' ]
```
